### PR TITLE
Update documentation build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,22 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+  configuration: doc/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/aiida_bands_inspect/calculations/difference.py
+++ b/aiida_bands_inspect/calculations/difference.py
@@ -10,11 +10,10 @@ import six
 
 from fsc.export import export
 
+from aiida import orm
 from aiida.engine import CalcJob
 from aiida.common import InputValidationError
 from aiida.common import CalcInfo, CodeInfo
-from aiida.orm import Float
-from aiida.plugins import DataFactory
 
 from ..io import write_bands
 
@@ -40,12 +39,12 @@ class DifferenceCalculation(CalcJob):
 
         spec.input(
             'bands1',
-            valid_type=DataFactory('array.bands'),
+            valid_type=orm.BandsData,
             help='First bandstructure which is to be compared'
         )
         spec.input(
             'bands2',
-            valid_type=DataFactory('array.bands'),
+            valid_type=orm.BandsData,
             help='Second bandstructure which is to be compared'
         )
 
@@ -55,7 +54,7 @@ class DifferenceCalculation(CalcJob):
             default='bands_inspect.difference'
         )
 
-        spec.output('difference', valid_type=Float)
+        spec.output('difference', valid_type=orm.Float)
 
         spec.exit_code(
             200,

--- a/aiida_bands_inspect/calculations/plot.py
+++ b/aiida_bands_inspect/calculations/plot.py
@@ -10,11 +10,11 @@ import six
 
 from fsc.export import export
 
+from aiida import orm
 from aiida.engine import CalcJob
 from aiida.common.utils import classproperty
 from aiida.common import InputValidationError
 from aiida.common import CalcInfo, CodeInfo
-from aiida.plugins import DataFactory
 
 from ..io import write_bands
 
@@ -40,12 +40,12 @@ class PlotCalculation(CalcJob):
 
         spec.input(
             'bands1',
-            valid_type=DataFactory('array.bands'),
+            valid_type=orm.BandsData,
             help="First bandstructure which is to be plotted"
         )
         spec.input(
             'bands2',
-            valid_type=DataFactory('array.bands'),
+            valid_type=orm.BandsData,
             help="Second bandstructure which is to be plotted"
         )
 
@@ -57,7 +57,7 @@ class PlotCalculation(CalcJob):
 
         spec.output(
             'plot',
-            valid_type=DataFactory('singlefile'),
+            valid_type=orm.SinglefileData,
             help='The created band-structure comparison plot.'
         )
 

--- a/aiida_bands_inspect/parsers/bands.py
+++ b/aiida_bands_inspect/parsers/bands.py
@@ -5,7 +5,6 @@
 
 from fsc.export import export
 
-from aiida.plugins import DataFactory
 from aiida.parsers.parser import Parser
 from ..io import read_bands
 

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,1 +1,2 @@
 build
+config.mk

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,32 +1,34 @@
 # Minimal makefile for Sphinx documentation
 #
+# Include local configuration (and its fallback version)
+-include config.mk
+include config_fallback.mk
 
-# You can set these variables from the command line.
-SPHINXOPTS    = -n
-SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = aiida-bands-inspect
-SOURCEDIR     = source
-BUILDDIR      = build
-TARGETDIR     = /home/greschd/programming/Z2Pack_website/web/aiida-plugins/aiida-bands-inspect
 
-.PHONY: all
+# User-friendly check for sphinx-build
+ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+endif
+
+# Internal variables.
+PAPEROPT_a4     = -D latex_paper_size=a4
+PAPEROPT_letter = -D latex_paper_size=letter
+ALLSPHINXOPTS   = -n -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+# the i18n builder cannot share the environment and doctrees with the others
+I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+
+.PHONY: all help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
+
 all: html
 
-# Put it first so that "make" without argument is like "make help".
-.PHONY: help
-help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+clean:
+	rm -r $(HTMLBUILDDIR)
+	rm -r $(BUILDDIR)
 
-.PHONY: view
+html:
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(HTMLBUILDDIR)
+	@echo
+	@echo "Build finished. The HTML pages are in $(HTMLBUILDDIR)."
+
 view:
-	xdg-open "$(BUILDDIR)"/html/index.html
-
-move:
-	-rm -r $(TARGETDIR)
-	mv $(BUILDDIR)/html $(TARGETDIR)
-
-# Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-.PHONY: Makefile
-%: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	xdg-open $(HTMLBUILDDIR)/index.html

--- a/doc/config_fallback.mk
+++ b/doc/config_fallback.mk
@@ -1,0 +1,7 @@
+# You can set these variables from the command line, or create a
+# 'config.mk' file to overwrite them.
+SPHINXOPTS ?= -n
+SPHINXBUILD ?= sphinx-build
+PAPER ?=
+BUILDDIR ?= build
+HTMLBUILDDIR  ?= $(BUILDDIR)/html

--- a/doc/requirements_for_rtd.txt
+++ b/doc/requirements_for_rtd.txt
@@ -1,2 +1,2 @@
-aiida-core>=1.0.0a1
+aiida-core>=1.0.0b6
 fsc.export

--- a/doc/requirements_for_rtd.txt
+++ b/doc/requirements_for_rtd.txt
@@ -1,2 +1,0 @@
-aiida-core>=1.0.0b6
-fsc.export

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -62,7 +62,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'aiida-bands-inspect'
-copyright = u'2018, Dominik Gresch'
+copyright = u'2017-2019, ETH Zurich'
 author = u'Dominik Gresch'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,27 +10,41 @@ sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir))
 os.environ['DJANGO_SETTINGS_MODULE'] = 'rtd_settings'
 
 import aiida
-from aiida.manage.configuration import settings
-
-# We set that we are in documentation mode - even for local compilation
-settings.IN_DOC_MODE = True
 
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed
 # from docs.readthedocs.org
-# NOTE: it is needed to have these lines before load_dbenv()
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
+# NOTE: it is needed to have these lines before load_dbenv()
 if not on_rtd:  # only import and set the theme if we're building docs locally
-    html_theme = 'sphinx_rtd_theme'
-    # Loading the dbenv. The backend should be fixed before compiling the
-    # documentation.
-    aiida.load_profile()
+    try:
+        import sphinx_rtd_theme
+        html_theme = 'sphinx_rtd_theme'
+        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+    except ImportError:
+        # No sphinx_rtd_theme installed
+        pass
+    # Load the database environment by first loading the profile and then loading the backend through the manager
+    from aiida.manage.configuration import get_config, load_profile
+    from aiida.manage.manager import get_manager
+    config = get_config()
+    load_profile(config.default_profile_name)
+    get_manager().get_backend()
 else:
-    # Back-end settings for readthedocs online documentation.
-    # from aiida.manage.configuration import settings
-    settings.IN_RT_DOC_MODE = True
-    settings.BACKEND = "django"
-    settings.AIIDADB_PROFILE = "default"
+    from aiida.manage import configuration
+    from aiida.manage.configuration import load_profile, reset_config
+    from aiida.manage.manager import get_manager
+
+    # Set the global variable to trigger shortcut behavior in `aiida.manager.configuration.load_config`
+    configuration.IN_RT_DOC_MODE = True
+
+    # First need to reset the config, because an empty one will have been loaded when `aiida` module got imported
+    reset_config()
+
+    # Load the profile: this will first load the config, which will be the dummy one for RTD purposes
+    load_profile()
+
+    # Finally load the database backend but without checking the schema because there is no actual database
+    get_manager()._load_backend(schema_check=False)
 
 import aiida_bands_inspect
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -46,6 +46,11 @@ else:
     # Finally load the database backend but without checking the schema because there is no actual database
     get_manager()._load_backend(schema_check=False)
 
+    # make sure all entry-points are detected, since readthedocs doesn't expose a way to do this
+    # during post-install.
+    import reentry
+    reentry.manager.scan()
+
 import aiida_bands_inspect
 
 # -- General configuration ------------------------------------------------

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -7,11 +7,11 @@ Reference
 Calculation classes
 -------------------
 
-.. autoclass:: aiida_bands_inspect.calculations.difference.DifferenceCalculation
-    :members:
+.. aiida-calcjob:: DifferenceCalculation
+    :module: aiida_bands_inspect.calculations.difference
 
-.. autoclass:: aiida_bands_inspect.calculations.plot.PlotCalculation
-    :members:
+.. aiida-calcjob:: PlotCalculation
+    :module: aiida_bands_inspect.calculations.plot
 
 Parser classes
 --------------

--- a/setup.json
+++ b/setup.json
@@ -38,6 +38,10 @@
       "pytest",
       "yapf==0.28",
       "pre-commit"
+    ],
+    "docs": [
+      "sphinx",
+      "sphinx-rtd-theme"
     ]
   },
   "entry_points": {

--- a/setup.json
+++ b/setup.json
@@ -27,7 +27,7 @@
   "reentry_register": true,
   "install_requires": [
     "h5py",
-    "aiida-core>=1.0.0a4,<2.0.0",
+    "aiida-core>=1.0.0b6,<2.0.0",
     "fsc.export",
     "six"
   ],


### PR DESCRIPTION
Fix the AiiDA configuration when building the documentation on readthedocs, and use the ``.readthedocs.yml`` to specify build parameters.

Also adds a separate ``docs`` extra requirement.