### PR TITLE
Use bands-inspect for io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .ropeproject
 dist
 .vscode
+.mypy_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,13 @@ repos:
   hooks:
   - id: yapf
     language: system
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.740
+  hooks:
+  - id: mypy
+    exclude: '^(doc/)|(examples/)|(utils/)'
+
 - repo: local
   hooks:
   - id: prospector

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,17 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+env:
+  - TEST_TYPE="tests"
+    INSTALL_TYPE="testing"
+  - TEST_TYPE="tests"
+    INSTALL_TYPE="testing_sdist"
+jobs:
+  include:
+    - python: "3.7"
+      env:
+        - TEST_TYPE="pre-commit"
+          INSTALL_TYPE="dev_precommit"
 cache: pip
 sudo: true
 services:
@@ -20,13 +31,6 @@ addons:
       - python3-matplotlib
       - python3-h5py
       - rabbitmq-server
-env:
-  - TEST_TYPE="pre-commit"
-    INSTALL_TYPE="dev_precommit"
-  - TEST_TYPE="tests"
-    INSTALL_TYPE="testing"
-  - TEST_TYPE="tests"
-    INSTALL_TYPE="testing_sdist"
 before_install:
   - sudo service postgresql restart
   - sudo pip3 install -U pip setuptools

--- a/aiida_bands_inspect/__init__.py
+++ b/aiida_bands_inspect/__init__.py
@@ -3,10 +3,11 @@
 # © 2017-2019, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from . import calculations
 from . import parsers
+from . import convert
 from . import io
 
-__all__ = ['calculations', 'parsers', 'io']
+__all__ = ('calculations', 'parsers', 'convert', 'io')

--- a/aiida_bands_inspect/calculations/align.py
+++ b/aiida_bands_inspect/calculations/align.py
@@ -8,16 +8,15 @@ Defines a calculation to run the ``bands-inspect align`` command.
 
 import six
 
-from fsc.export import export
-
 from aiida.engine import CalcJob
 from aiida.common import CalcInfo, CodeInfo
 from aiida.plugins import DataFactory
 
 from ..io import write_bands
 
+__all__ = ('AlignCalculation', )
 
-@export
+
 class AlignCalculation(CalcJob):
     """
     Calculation class for the ``bands-inspect align`` command.

--- a/aiida_bands_inspect/calculations/difference.py
+++ b/aiida_bands_inspect/calculations/difference.py
@@ -6,16 +6,15 @@
 Defines a calculation to run the ``bands-inspect difference`` command.
 """
 
-from fsc.export import export
-
 from aiida import orm
 from aiida.engine import CalcJob
 from aiida.common import CalcInfo, CodeInfo
 
 from ..io import write_bands
 
+__all__ = ('DifferenceCalculation', )
 
-@export
+
 class DifferenceCalculation(CalcJob):
     """
     Calculation class for the ``bands-inspect difference`` command.

--- a/aiida_bands_inspect/calculations/plot.py
+++ b/aiida_bands_inspect/calculations/plot.py
@@ -6,16 +6,15 @@
 Defines the a calculation class for the ``bands-inspect plot`` command.
 """
 
-from fsc.export import export
-
 from aiida import orm
 from aiida.engine import CalcJob
 from aiida.common import CalcInfo, CodeInfo
 
 from ..io import write_bands
 
+__all__ = ('PlotCalculation', )
 
-@export
+
 class PlotCalculation(CalcJob):
     """
     Calculation class for the ``bands_inspect plot`` command.

--- a/aiida_bands_inspect/convert.py
+++ b/aiida_bands_inspect/convert.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""
+Defines functions for converting AiiDA Data to and from bands-inspect format.
+"""
+
+import typing as ty
+from functools import singledispatch
+
+from aiida import orm
+
+from bands_inspect.kpoints import KpointsBase, KpointsExplicit, KpointsMesh
+from bands_inspect.eigenvals import EigenvalsData
+
+__all__ = ('from_bands_inspect', 'to_bands_inspect')
+
+
+@singledispatch
+def from_bands_inspect(data: ty.Union[KpointsBase, EigenvalsData]
+                       ) -> ty.Union[orm.KpointsData, orm.BandsData]:
+    raise NotImplementedError(
+        f'Cannot convert data type {type(data)} to AiiDA data.'
+    )
+
+
+@from_bands_inspect.register(KpointsMesh)
+def _from_bands_inspect_kpoints_mesh(data: KpointsMesh) -> orm.KpointsData:
+    kpoints = orm.KpointsData()
+    kpoints.set_kpoints_mesh(mesh=data.mesh, offset=data.offset)
+    return kpoints
+
+
+@from_bands_inspect.register(KpointsExplicit)
+def _from_bands_inspect_kpoints_explicit(
+    data: KpointsExplicit
+) -> orm.KpointsData:
+    kpoints = orm.KpointsData()
+    kpoints.set_kpoints(data.kpoints)
+    return kpoints
+
+
+@from_bands_inspect.register(EigenvalsData)
+def _from_bands_inspect_eigenvals_data(data: EigenvalsData) -> orm.BandsData:
+    bands = orm.BandsData()
+    kpoints = from_bands_inspect(data.kpoints)
+    if 'mesh' in kpoints.attributes:
+        bands.set_kpoints(kpoints.get_kpoints_mesh(print_list=True))
+    else:
+        bands.set_kpointsdata(kpoints)
+    bands.set_bands(data.eigenvals)
+    return bands
+
+
+@singledispatch
+def to_bands_inspect(data: ty.Union[orm.KpointsData, orm.BandsData]
+                     ) -> ty.Union[KpointsBase, EigenvalsData]:
+    raise NotImplementedError(
+        f'Cannot convert data type {type(data)} to bands-inspect object.'
+    )
+
+
+@to_bands_inspect.register(orm.KpointsData)
+def _kpointsdata_to_bands_inspect(data: orm.KpointsData) -> KpointsBase:
+    attributes = data.attributes
+    if 'mesh' in attributes:
+        return KpointsMesh(
+            mesh=attributes['mesh'], offset=attributes['offset']
+        )
+    if 'array|kpoints' in attributes:
+        return KpointsExplicit(kpoints=data.get_kpoints())
+    raise NotImplementedError(
+        f"Unrecognized KpointsData form, has attributes '{attributes}'"
+    )
+
+
+@to_bands_inspect.register(orm.BandsData)
+def _bandsdata_to_bands_inspect(data: orm.BandsData) -> EigenvalsData:
+    bands_arr = data.get_bands()
+    if len(bands_arr.shape) == 3:
+        assert bands_arr.shape[0] == 1
+        bands_arr = bands_arr[0, :, :]
+    return EigenvalsData(
+        kpoints=_kpointsdata_to_bands_inspect(data), eigenvals=bands_arr
+    )

--- a/aiida_bands_inspect/convert.py
+++ b/aiida_bands_inspect/convert.py
@@ -17,6 +17,7 @@ __all__ = ('from_bands_inspect', 'to_bands_inspect')
 @singledispatch
 def from_bands_inspect(data: ty.Union[KpointsBase, EigenvalsData]
                        ) -> ty.Union[orm.KpointsData, orm.BandsData]:
+    """Convert bands-inspect data instances into AiiDA data nodes."""
     raise NotImplementedError(
         f'Cannot convert data type {type(data)} to AiiDA data.'
     )
@@ -53,6 +54,7 @@ def _from_bands_inspect_eigenvals_data(data: EigenvalsData) -> orm.BandsData:
 @singledispatch
 def to_bands_inspect(data: ty.Union[orm.KpointsData, orm.BandsData]
                      ) -> ty.Union[KpointsBase, EigenvalsData]:
+    """Convert AiiDA data nodes into bands-inspect data instances."""
     raise NotImplementedError(
         f'Cannot convert data type {type(data)} to bands-inspect object.'
     )

--- a/aiida_bands_inspect/io.py
+++ b/aiida_bands_inspect/io.py
@@ -3,6 +3,10 @@
 
 # © 2017-2019, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
+"""
+Defines functions for reading and writing bands-inspect HDF5 files
+from / to AiiDA Data nodes.
+"""
 
 import warnings
 

--- a/aiida_bands_inspect/io.py
+++ b/aiida_bands_inspect/io.py
@@ -4,85 +4,116 @@
 # © 2017-2019, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
-from __future__ import division, print_function, unicode_literals
+import warnings
 
-import h5py
-import numpy as np
+from aiida import orm
+from bands_inspect.io import save, load
 
-from aiida.plugins import DataFactory
+from .convert import from_bands_inspect, to_bands_inspect
+
+__all__ = ('read', 'write')
 
 
-def write_kpoints(kpoints_data, *args, **kwargs):
+def write(data: orm.Data, filename: str) -> None:
     """
-    Write a 'KpointsData' instance to a file or file-like object in bands_inspect HDF5 format. Except for ``kpoints_data``, all positional
-    and keyword arguments are passed to :class:`h5py.File`.
+    Write an AiiDA Data instance to a file in bands_inspect HDF5 format.
+
+    Parameters
+    ----------
+    data :
+        The AiiDA data instance to be written.
+    filename :
+        Path of the file being written to.
     """
-    # This can be replaced with bands_inspect.io functions when
-    # AiiDA supports Python 3.
-    with h5py.File(*args, **kwargs) as f:
-        _serialize_kpoints(kpoints_data, f)
+    save(to_bands_inspect(data), hdf5_file=filename)
 
 
-def _serialize_kpoints(kpoints_data, hdf5_handle):
-    attrs = kpoints_data.attributes
-    if 'mesh' in attrs:
-        hdf5_handle['type_tag'] = 'kpoints_mesh'
-        hdf5_handle['mesh'] = np.array(attrs['mesh'])
-        hdf5_handle['offset'] = np.array(attrs['offset'])
-    elif 'array|kpoints' in attrs:
-        hdf5_handle['type_tag'] = 'kpoints_explicit'
-        hdf5_handle['kpoints'] = np.array(kpoints_data.get_kpoints())
-    else:
-        raise NotImplementedError(
-            "Unrecognized KpointsData form, has attrs '{}'".format(attrs)
-        )
-
-
-def read_bands(*args, **kwargs):
+def write_kpoints(kpoints_data, filename):
     """
-    Read a HDF5 in bands_inspect HDF5 format containing an EigenvalsData
-    instance, and return an AiiDA BandsData instance. Positional and keyword
-    arguments are passed to :class:`h5py.File`.
+    .. note:: This function is deprecated, use :func:`write` instead.
+
+    Write an AiiDA Data instance to a file in bands_inspect HDF5 format.
+
+    Parameters
+    ----------
+    data :
+        The AiiDA data instance to be written.
+    filename :
+        Path of the file being written to.
     """
-    with h5py.File(*args, **kwargs) as f:
-        kpoints = _parse_kpoints(f['kpoints_obj'])
-        # BandsData cannot have a mesh as k-points...
-        bands = DataFactory('array.bands')()
-        if 'mesh' in kpoints.attributes:
-            bands.set_kpoints(kpoints.get_kpoints_mesh(print_list=True))
-        else:
-            bands.set_kpointsdata(kpoints)
-        bands.set_bands(f['eigenvals'].value)
-    return bands
-
-
-def _parse_kpoints(hdf5_handle):
-    type_tag = hdf5_handle['type_tag'].value
-    kpoints = DataFactory('array.kpoints')()
-    if 'kpoints_mesh' in type_tag:
-        kpoints.set_kpoints_mesh(
-            hdf5_handle['mesh'].value, hdf5_handle['offset'].value
-        )
-    elif 'kpoints_explicit' in type_tag:
-        kpoints.set_kpoints(hdf5_handle['kpoints'].value)
-    else:
-        raise NotImplementedError(
-            "Unrecognized type_tag '{}' encountered when parsing k-points data."
-            .format(type_tag)
-        )
-    return kpoints
+    warnings.warn(
+        "The 'write_kpoints' function is deprecated, use 'write' instead",
+        DeprecationWarning
+    )
+    write(data=kpoints_data, filename=filename)
 
 
 def write_bands(bands_data, filename):
     """
-    Write a 'BandsData' instance to a file in bands_inspect HDF5 format.
+    .. note:: This function is deprecated, use :func:`write` instead.
+
+    Write an AiiDA Data instance to a file in bands_inspect HDF5 format.
+
+    Parameters
+    ----------
+    data :
+        The AiiDA data instance to be written.
+    filename :
+        Path of the file being written to.
     """
-    with h5py.File(filename, 'w') as f:
-        kpt = f.create_group('kpoints_obj')
-        _serialize_kpoints(bands_data, kpt)
-        bands_arr = bands_data.get_bands()
-        if len(bands_arr.shape) == 3:
-            assert bands_arr.shape[0] == 1
-            bands_arr = bands_arr[0, :, :]
-        f['eigenvals'] = bands_arr
-        f['type_tag'] = 'bands_inspect.eigenvals_data'
+    warnings.warn(
+        "The 'write_bands' function is deprecated, use 'write' instead",
+        DeprecationWarning
+    )
+    write(data=bands_data, filename=filename)
+
+
+def read(filename: str) -> orm.Data:
+    """
+    Read a HDF5 file in bands_inspect format, and return a corresponding
+    AiiDA Data instance.
+
+    Parameters
+    ----------
+    filename : str
+        Path of the file to be read.
+    """
+    return from_bands_inspect(load(hdf5_file=filename))
+
+
+def read_kpoints(filename):
+    """
+    .. note:: This function is deprecated, use :func:`read` instead.
+
+    Read a HDF5 file in bands_inspect format, and return a corresponding
+    AiiDA Data instance.
+
+    Parameters
+    ----------
+    filename : str
+        Path of the file to be read.
+    """
+    warnings.warn(
+        "The 'read_kpoints' function is deprecated, use 'read' instead",
+        DeprecationWarning
+    )
+    return read(filename)
+
+
+def read_bands(filename):
+    """
+    .. note:: This function is deprecated, use :func:`read` instead.
+
+    Read a HDF5 file in bands_inspect format, and return a corresponding
+    AiiDA Data instance.
+
+    Parameters
+    ----------
+    filename : str
+        Path of the file to be read.
+    """
+    warnings.warn(
+        "The 'read_bands' function is deprecated, use 'read' instead",
+        DeprecationWarning
+    )
+    return read(filename)

--- a/aiida_bands_inspect/parsers/align.py
+++ b/aiida_bands_inspect/parsers/align.py
@@ -3,15 +3,14 @@
 # © 2017-2019, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
-from fsc.export import export
-
 from aiida.plugins import DataFactory
 from aiida.parsers.parser import Parser
-from ..io import read_bands
+from ..io import read
 from ..calculations.align import AlignCalculation
 
+__all__ = ('AlignParser', )
 
-@export
+
 class AlignParser(Parser):
     """
     Parse output of the align command: The shifted eigenvals files to
@@ -39,13 +38,13 @@ class AlignParser(Parser):
                 AlignCalculation._EV1_SHIFTED_FILENAME,  # pylint: disable=protected-access
                 'r+b'
             ) as ev1_shifted_file:
-                self.out('bands1_shifted', read_bands(ev1_shifted_file))
+                self.out('bands1_shifted', read(ev1_shifted_file))
 
             with out_folder.open(
                 AlignCalculation._EV2_SHIFTED_FILENAME,  # pylint: disable=protected-access
                 'r+b'
             ) as ev2_shifted_file:
-                self.out('bands2_shifted', read_bands(ev2_shifted_file))
+                self.out('bands2_shifted', read(ev2_shifted_file))
 
             with out_folder.open(
                 AlignCalculation._OUTPUT_FILE_NAME,  # pylint: disable=protected-access

--- a/aiida_bands_inspect/parsers/bands.py
+++ b/aiida_bands_inspect/parsers/bands.py
@@ -3,13 +3,12 @@
 # © 2017-2019, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
-from fsc.export import export
-
 from aiida.parsers.parser import Parser
-from ..io import read_bands
+from ..io import read
+
+__all__ = ('BandsParser', )
 
 
-@export
 class BandsParser(Parser):
     """
     Parse bands_inspect eigenvals file to a BandsData object.
@@ -28,4 +27,4 @@ class BandsParser(Parser):
         with out_folder.open(
             self.node.get_option('output_filename'), 'r+b'
         ) as out_file:
-            self.out('bands', read_bands(out_file))
+            self.out('bands', read(out_file))

--- a/aiida_bands_inspect/parsers/difference.py
+++ b/aiida_bands_inspect/parsers/difference.py
@@ -3,15 +3,14 @@
 # © 2017-2019, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
-from fsc.export import export
-
 from aiida.orm import Float
 from aiida.parsers.parser import Parser
 
 from ..calculations.difference import DifferenceCalculation
 
+__all__ = ('DifferenceParser', )
 
-@export
+
 class DifferenceParser(Parser):
     """
     Parse ``bands_inspect difference`` output to float.

--- a/aiida_bands_inspect/parsers/plot.py
+++ b/aiida_bands_inspect/parsers/plot.py
@@ -3,15 +3,14 @@
 # © 2017-2019, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
-from fsc.export import export
-
 from aiida.plugins import DataFactory
 from aiida.parsers.parser import Parser
 
 from ..calculations.plot import PlotCalculation
 
+__all__ = ('PlotParser', )
 
-@export
+
 class PlotParser(Parser):
     """
     Parse ``bands-inspect plot_bands`` output to a 'singlefile' data.

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -24,3 +24,19 @@ Parser classes
 .. autoclass:: aiida_bands_inspect.parsers.difference.DifferenceParser
 
 .. autoclass:: aiida_bands_inspect.parsers.plot.PlotParser
+
+
+Helper modules
+--------------
+
+aiida_bands_inspect.convert
+'''''''''''''''''''''''''''
+
+.. automodule:: aiida_bands_inspect.convert
+    :members:
+
+aiida_bands_inspect.io
+''''''''''''''''''''''
+
+.. automodule:: aiida_bands_inspect.io
+    :members:

--- a/examples/difference/run.py
+++ b/examples/difference/run.py
@@ -4,8 +4,6 @@
 # © 2017-2019, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
-from __future__ import division, print_function, unicode_literals
-
 from aiida.orm import Code
 from aiida.plugins import DataFactory, CalculationFactory
 from aiida.engine import run

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,41 @@
+# Global options
+
+[mypy]
+python_version = 3.7
+
+; Strictness settings
+; disallow_any_unimported = True
+; disallow_any_expr = True
+; disallow_any_decorated = True
+; disallow_any_explicit = True
+disallow_any_generics = True
+; disallow_subclassing_any = True
+
+; disallow_untyped_calls = True
+; disallow_untyped_defs = True
+; disallow_incomplete_defs = True
+; disallow_untyped_decorators = True
+
+no_implicit_optional = True
+no_strict_optional = False
+
+; Enable all warnings
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_unreachable = True
+
+allow_untyped_globals = False
+strict_equality = True
+
+[mypy-aiida.*]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-aiida_tools.*]
+ignore_missing_imports = True

--- a/setup.json
+++ b/setup.json
@@ -30,7 +30,6 @@
   "reentry_register": true,
   "install_requires": [
     "numpy",
-    "h5py",
     "aiida-core>=1.0.0,<2.0.0",
     "bands-inspect"
   ],

--- a/setup.json
+++ b/setup.json
@@ -23,6 +23,7 @@
     "workflows"
   ],
   "include_package_data": true,
+  "python_requires": ">=3.6",
   "setup_requires": [
     "reentry"
   ],

--- a/setup.json
+++ b/setup.json
@@ -31,7 +31,7 @@
     "numpy",
     "h5py",
     "aiida-core>=1.0.0,<2.0.0",
-    "fsc.export"
+    "bands-inspect"
   ],
   "extras_require": {
     "testing": [

--- a/setup.json
+++ b/setup.json
@@ -1,7 +1,7 @@
 {
   "name": "aiida-bands-inspect",
   "description": "AiiDA Plugin for running bands_inspect",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Dominik Gresch",
   "author_email": "greschd@gmx.ch",
   "url": "https://aiida-bands-inspect.readthedocs.io",

--- a/tests/test_difference.py
+++ b/tests/test_difference.py
@@ -5,8 +5,6 @@
 # © 2017-2019, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
-from __future__ import division, unicode_literals, print_function
-
 import subprocess
 
 import pytest

--- a/tests/test_io_deprecated.py
+++ b/tests/test_io_deprecated.py
@@ -18,32 +18,37 @@ import numpy as np
 )
 def test_write_read_bands(configure, bands_params):  # pylint: disable=unused-argument
     from aiida.plugins import DataFactory
-    from aiida_bands_inspect.io import read, write
+    from aiida_bands_inspect.io import read_bands, write_bands
     BandsData = DataFactory('array.bands')
     bands = BandsData()
     bands.set_kpoints(bands_params['kpoints'])
     bands.set_bands(bands_params['eigenvals'])
     with tempfile.NamedTemporaryFile() as tmpf:
-        write(bands, tmpf.name)
-        res = read(tmpf.name)
+        with pytest.warns(DeprecationWarning):
+            write_bands(bands, tmpf.name)
+        with pytest.warns(DeprecationWarning):
+            res = read_bands(tmpf.name)
     assert np.allclose(res.get_kpoints(), bands.get_kpoints())
     assert np.allclose(res.get_bands(), bands.get_bands())
 
 
 def test_write_read_kpoints(configure):  # pylint: disable=unused-argument
     from aiida.plugins import DataFactory
-    from aiida_bands_inspect.io import read, write
+    from aiida_bands_inspect.io import read_kpoints, write_kpoints
     KpointsData = DataFactory('array.kpoints')
     kpoints = KpointsData()
     kpoints.set_kpoints([[0., 0., 0.]])
     with tempfile.NamedTemporaryFile() as tmpf:
-        write(kpoints, tmpf.name)
-        res = read(tmpf.name)
+        with pytest.warns(DeprecationWarning):
+            write_kpoints(kpoints, tmpf.name)
+        with pytest.warns(DeprecationWarning):
+            res = read_kpoints(tmpf.name)
     assert np.allclose(res.get_kpoints(), kpoints.get_kpoints())
 
 
 def test_read(configure, sample):  # pylint: disable=unused-argument
-    from aiida_bands_inspect.io import read
-    res = read(sample('bands_mesh.hdf5'))
+    from aiida_bands_inspect.io import read_bands
+    with pytest.warns(DeprecationWarning):
+        res = read_bands(sample('bands_mesh.hdf5'))
     assert np.allclose(res.get_kpoints(), [[0., 0., 0.], [0., 0., 0.5]])
     assert np.allclose(res.get_bands(), [[1, 2], [3, 4]])

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -4,8 +4,6 @@
 # © 2017-2019, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
-from __future__ import division, unicode_literals
-
 import pytest
 
 


### PR DESCRIPTION
Fixes #18.

Also adds a 'convert' helper module to directly convert to / from the bands-inspect format, without going through an HDF5 file.