### PR TITLE
Read bands file from 'result_filename' option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: git://github.com/pre-commit/mirrors-yapf
-  rev: v0.28.0
+  rev: v0.29.0
   hooks:
   - id: yapf
     language: system
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.740
+  rev: v0.770
   hooks:
   - id: mypy
     exclude: '^(doc/)|(examples/)|(utils/)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 python:
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ jobs:
         - TEST_TYPE="pre-commit"
           INSTALL_TYPE="dev_precommit"
 cache: pip
-sudo: true
 services:
   - rabbitmq
   - postgresql
@@ -32,10 +31,10 @@ addons:
       - python3-h5py
       - rabbitmq-server
 before_install:
-  - sudo service postgresql restart
-  - sudo pip3 install -U pip setuptools
-  - sudo pip3 install -U matplotlib
-  - sudo pip3 install bands-inspect
+  - pip install -U pip setuptools
+  - pip install -U numpy scipy
+  - pip install -U matplotlib
+  - pip install bands-inspect
 install:
   - ./.travis-data/install_script.sh
 script:

--- a/aiida_bands_inspect/__init__.py
+++ b/aiida_bands_inspect/__init__.py
@@ -3,7 +3,7 @@
 # © 2017-2019, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 from . import calculations
 from . import parsers

--- a/aiida_bands_inspect/convert.py
+++ b/aiida_bands_inspect/convert.py
@@ -15,8 +15,9 @@ __all__ = ('from_bands_inspect', 'to_bands_inspect')
 
 
 @singledispatch
-def from_bands_inspect(data: ty.Union[KpointsBase, EigenvalsData]
-                       ) -> ty.Union[orm.KpointsData, orm.BandsData]:
+def from_bands_inspect(
+    data: ty.Union[KpointsBase, EigenvalsData]
+) -> ty.Union[orm.KpointsData, orm.BandsData]:
     """Convert bands-inspect data instances into AiiDA data nodes."""
     raise NotImplementedError(
         f'Cannot convert data type {type(data)} to AiiDA data.'
@@ -52,8 +53,9 @@ def _from_bands_inspect_eigenvals_data(data: EigenvalsData) -> orm.BandsData:
 
 
 @singledispatch
-def to_bands_inspect(data: ty.Union[orm.KpointsData, orm.BandsData]
-                     ) -> ty.Union[KpointsBase, EigenvalsData]:
+def to_bands_inspect(
+    data: ty.Union[orm.KpointsData, orm.BandsData]
+) -> ty.Union[KpointsBase, EigenvalsData]:
     """Convert AiiDA data nodes into bands-inspect data instances."""
     raise NotImplementedError(
         f'Cannot convert data type {type(data)} to bands-inspect object.'

--- a/aiida_bands_inspect/parsers/bands.py
+++ b/aiida_bands_inspect/parsers/bands.py
@@ -18,7 +18,7 @@ class BandsParser(Parser):
     bands : aiida.orm.nodes.data.array.bands.BandsData
         Retrieved band structure.
     """
-    def parse(self, **kwargs):
+    def parse(self, **kwargs):  # pylint: disable=inconsistent-return-statements
         try:
             out_folder = self.retrieved
         except KeyError:
@@ -28,5 +28,8 @@ class BandsParser(Parser):
         # For compatibility with aiida-tbmodels <= 0.3
         if result_filename is None:
             result_filename = self.node.get_option('output_filename')
-        with out_folder.open(result_filename, 'rb') as out_file:
-            self.out('bands', read(out_file))
+        try:
+            with out_folder.open(result_filename, 'rb') as out_file:
+                self.out('bands', read(out_file))
+        except IOError:
+            return self.exit_codes.ERROR_RESULT_FILE

--- a/aiida_bands_inspect/parsers/bands.py
+++ b/aiida_bands_inspect/parsers/bands.py
@@ -24,7 +24,9 @@ class BandsParser(Parser):
         except KeyError:
             self.logger.error("No retrieved folder found")
 
-        with out_folder.open(
-            self.node.get_option('output_filename'), 'r+b'
-        ) as out_file:
+        result_filename = self.node.get_option('result_filename')
+        # For compatibility with aiida-tbmodels <= 0.3
+        if result_filename is None:
+            result_filename = self.node.get_option('output_filename')
+        with out_folder.open(result_filename, 'rb') as out_file:
             self.out('bands', read(out_file))

--- a/setup.json
+++ b/setup.json
@@ -1,7 +1,7 @@
 {
   "name": "aiida-bands-inspect",
   "description": "AiiDA Plugin for running bands_inspect",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": "Dominik Gresch",
   "author_email": "greschd@gmx.ch",
   "url": "https://aiida-bands-inspect.readthedocs.io",
@@ -39,10 +39,10 @@
       "pytest"
     ],
     "dev_precommit": [
-      "yapf==0.28",
-      "pre-commit==1.20.0",
-      "prospector==1.1.7",
-      "pylint==2.3.1",
+      "yapf==0.29",
+      "pre-commit==2.2.0",
+      "prospector==1.2.0",
+      "pylint==2.4.4",
       "pyflakes==1.6.0"
     ],
     "docs": [

--- a/tests/test_difference.py
+++ b/tests/test_difference.py
@@ -5,16 +5,16 @@
 # © 2017-2019, ETH Zurich, Institut für Theoretische Physik
 # Author: Dominik Gresch <greschd@gmx.ch>
 
-import subprocess
-
 import pytest
 import numpy as np
+
+from aiida.plugins import DataFactory
+from aiida.engine.launch import run_get_node
+from aiida.manage.caching import enable_caching
 
 
 @pytest.fixture
 def get_bands_builder(get_process_builder):
-    from aiida.plugins import DataFactory
-
     builder = get_process_builder(
         calculation_string='bands_inspect.difference',
         code_string='bands_inspect'
@@ -35,28 +35,17 @@ def get_bands_builder(get_process_builder):
 
 
 def test_difference(configure_with_daemon, get_bands_builder):  # pylint: disable=unused-argument
-    from aiida.engine.launch import run_get_node
-
     builder = get_bands_builder
     output, calc_node = run_get_node(builder)
-    print('State:', calc_node.get_state())
-    print('Output:', output)
-    print(
-        subprocess.check_output([
-            "verdi", "process", "report", "{}".format(calc_node.pk)
-        ],
-                                stderr=subprocess.STDOUT)
-    )
+
     assert np.isclose(output['difference'].value, 1 / 3)
+    assert calc_node.is_finished_ok
 
 
 def test_difference_cache(
     configure_with_daemon,  # pylint: disable=unused-argument
     get_bands_builder,
 ):
-    from aiida.engine.launch import run_get_node
-    from aiida.manage.caching import enable_caching
-
     builder = get_bands_builder
 
     # Fast-forwarding is enabled in the configuration for DifferenceCalculation

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -9,6 +9,9 @@ import tempfile
 import pytest
 import numpy as np
 
+from aiida.plugins import DataFactory
+from aiida_bands_inspect.io import read, write
+
 
 @pytest.mark.parametrize(
     'bands_params', [{
@@ -17,8 +20,6 @@ import numpy as np
     }]
 )
 def test_write_read_bands(configure, bands_params):  # pylint: disable=unused-argument
-    from aiida.plugins import DataFactory
-    from aiida_bands_inspect.io import read, write
     BandsData = DataFactory('array.bands')
     bands = BandsData()
     bands.set_kpoints(bands_params['kpoints'])
@@ -31,8 +32,6 @@ def test_write_read_bands(configure, bands_params):  # pylint: disable=unused-ar
 
 
 def test_write_read_kpoints(configure):  # pylint: disable=unused-argument
-    from aiida.plugins import DataFactory
-    from aiida_bands_inspect.io import read, write
     KpointsData = DataFactory('array.kpoints')
     kpoints = KpointsData()
     kpoints.set_kpoints([[0., 0., 0.]])
@@ -43,7 +42,6 @@ def test_write_read_kpoints(configure):  # pylint: disable=unused-argument
 
 
 def test_read(configure, sample):  # pylint: disable=unused-argument
-    from aiida_bands_inspect.io import read
     res = read(sample('bands_mesh.hdf5'))
     assert np.allclose(res.get_kpoints(), [[0., 0., 0.], [0., 0., 0.5]])
     assert np.allclose(res.get_bands(), [[1, 2], [3, 4]])

--- a/tests/test_io_deprecated.py
+++ b/tests/test_io_deprecated.py
@@ -9,6 +9,9 @@ import tempfile
 import pytest
 import numpy as np
 
+from aiida.plugins import DataFactory
+from aiida_bands_inspect.io import read_bands, write_bands, write_kpoints, read_kpoints
+
 
 @pytest.mark.parametrize(
     'bands_params', [{
@@ -17,8 +20,6 @@ import numpy as np
     }]
 )
 def test_write_read_bands(configure, bands_params):  # pylint: disable=unused-argument
-    from aiida.plugins import DataFactory
-    from aiida_bands_inspect.io import read_bands, write_bands
     BandsData = DataFactory('array.bands')
     bands = BandsData()
     bands.set_kpoints(bands_params['kpoints'])
@@ -33,8 +34,6 @@ def test_write_read_bands(configure, bands_params):  # pylint: disable=unused-ar
 
 
 def test_write_read_kpoints(configure):  # pylint: disable=unused-argument
-    from aiida.plugins import DataFactory
-    from aiida_bands_inspect.io import read_kpoints, write_kpoints
     KpointsData = DataFactory('array.kpoints')
     kpoints = KpointsData()
     kpoints.set_kpoints([[0., 0., 0.]])
@@ -47,7 +46,6 @@ def test_write_read_kpoints(configure):  # pylint: disable=unused-argument
 
 
 def test_read(configure, sample):  # pylint: disable=unused-argument
-    from aiida_bands_inspect.io import read_bands
     with pytest.warns(DeprecationWarning):
         res = read_bands(sample('bands_mesh.hdf5'))
     assert np.allclose(res.get_kpoints(), [[0., 0., 0.], [0., 0., 0.5]])

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -6,11 +6,12 @@
 
 import pytest
 
+from aiida.engine.launch import run
+from aiida.plugins import DataFactory
+
 
 @pytest.fixture
 def get_plot_builder(get_process_builder):
-    from aiida.plugins import DataFactory
-
     builder = get_process_builder(
         calculation_string='bands_inspect.plot', code_string='bands_inspect'
     )
@@ -30,9 +31,6 @@ def get_plot_builder(get_process_builder):
 
 
 def test_plot(configure_with_daemon, get_plot_builder):  # pylint: disable=unused-argument
-    from aiida.engine.launch import run
-    from aiida.plugins import DataFactory
-
     builder = get_plot_builder
     output = run(builder)
     print(


### PR DESCRIPTION
Before, it would be read from the `output_filename` option. This is still retained as a fallback, to be compatible with older versions of aiida-tbmodels which don't have the `result_filename` option.